### PR TITLE
Fix db seed with api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem "jbuilder"
 gem "devise"
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
-
+gem 'faker'
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
       railties (>= 3.2)
     erubi (1.12.0)
     execjs (2.8.1)
+    faker (3.1.1)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     font-awesome-sass (6.2.1)
       sassc (~> 2.0)
@@ -257,6 +259,7 @@ DEPENDENCIES
   debug
   devise
   dotenv-rails
+  faker
   font-awesome-sass (~> 6.1)
   jbuilder
   jsbundling-rails

--- a/db/migrate/20230206132941_add_phone_number_to_venues.rb
+++ b/db/migrate/20230206132941_add_phone_number_to_venues.rb
@@ -1,5 +1,0 @@
-class AddPhoneNumberToVenues < ActiveRecord::Migration[7.0]
-  def change
-    add_column :venues, :phone_number, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_06_132941) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_06_221016) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Hi guys, I have fixed the API seeding issue. We now have unique-ish records from the API to play with. Alternatively, this can be commented out if you want to use Faker instead. Faker has a uniqueness option too (incase that is important). We may want to continue with this API as the coords it gives us can be used with mapbox for geolocation etc.

This may occasionally crash, if it has a record with an empty company name (but this is desirable anyway as we wouldn't want missing fields in our database). Also, seeding the database is not a feature of our MVP anyway!

For a better demo we could seed it with genuine names of rehearsal studios from the uk - i know a few in London if we want five genuine ones to play with.

But this will give us something to play with tomorrow.

