### PR TITLE
Refine seed file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ ruby "3.1.2"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.4", ">= 7.0.4.2"
 
+gem "open-uri"
+
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,10 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
+    open-uri (0.3.0)
+      stringio
+      time
+      uri
     orm_adapter (0.5.0)
     pg (1.4.5)
     public_suffix (5.0.1)
@@ -238,8 +242,11 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
+    stringio (3.0.5)
     thor (1.2.1)
     tilt (2.0.11)
+    time (0.2.1)
+      date
     timeout (0.3.1)
     turbo-rails (1.3.3)
       actionpack (>= 6.0.0)
@@ -250,6 +257,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
+    uri (0.12.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -285,6 +293,7 @@ DEPENDENCIES
   font-awesome-sass (~> 6.1)
   jbuilder
   jsbundling-rails
+  open-uri
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.2)

--- a/app/testapi.rb
+++ b/app/testapi.rb
@@ -1,0 +1,9 @@
+require 'open-uri'
+require 'json'
+
+
+
+url = `https://maps.googleapis.com/maps/api/place/findplacefromtext/json?fields=formatted_address%2Cname%2Crating%2Copening_hours%2Cgeometry&input=music%rehearsal%venues&inputtype=textquery&key=AIzaSyBhvbimgkK3MN2tHSRtpXDkLFYq91kmQHk`
+
+response = URI.open(url).read
+puts response

--- a/app/testapi.rb
+++ b/app/testapi.rb
@@ -1,9 +1,0 @@
-require 'open-uri'
-require 'json'
-
-
-
-url = `https://maps.googleapis.com/maps/api/place/findplacefromtext/json?fields=formatted_address%2Cname%2Crating%2Copening_hours%2Cgeometry&input=music%rehearsal%venues&inputtype=textquery&key=AIzaSyBhvbimgkK3MN2tHSRtpXDkLFYq91kmQHk`
-
-response = URI.open(url).read
-puts response

--- a/db/migrate/20230207165552_add_phone_number_to_venues.rb
+++ b/db/migrate/20230207165552_add_phone_number_to_venues.rb
@@ -1,5 +1,7 @@
 class AddPhoneNumberToVenues < ActiveRecord::Migration[7.0]
   def change
+    unless column_exists? :venues, :phone_number
     add_column :venues, :phone_number, :string
   end
+end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_07_174337) do
   enable_extension "plpgsql"
 
   create_table "bookings", force: :cascade do |t|
-    t.boolean "confirmed"
+    t.boolean "confirmed", default: false
     t.bigint "venue_id", null: false
     t.bigint "user_id", null: false
     t.date "start_date"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,32 @@
 require 'date'
+require 'open-uri'
+require 'json'
+
+api_key = 'AIzaSyBhvbimgkK3MN2tHSRtpXDkLFYq91kmQHk'
+
+# we could pass other queries to this string in terms of location and search terms. I have also limited the number of results to 15.
+
+url = "https://maps.googleapis.com/maps/api/place/textsearch/json?query=music%20rehearsal%20venues%20in%20London&limit=15
+  &key=#{api_key}"
+
+response = URI.open(url).read
+
+parsed_response = JSON.parse(response)
+music_venues = parsed_response['results']
+
+# For checking the response and logic
+# p music_venues.count
+
+# music_venues.each do |music_venue|
+#   puts "venue name:"
+#   puts music_venue['name']
+#   puts "-----------------------"
+#   puts "address:"
+#   puts music_venue['formatted_address']['']
+
+# end
+
+# puts music_venues.sample
 
 #-----CLEANING DB-----
 puts "destroying review database"
@@ -14,7 +42,7 @@ puts "destroying user database"
 User.destroy_all
 
 # -----------------
-
+# do we want make passwords unique?
 puts "creating users"
 20.times do
   user = User.new(
@@ -29,17 +57,23 @@ end
 puts "creating venues"
 15.times do
   user = User.all.sample
+  rehearsal_venue = music_venues.sample
   venue = Venue.new(
-    name: Faker::Kpop.iii_groups,
+    name: rehearsal_venue['name'],
     price_per_day: rand(50..100),
-    location: "#{Faker::Address.street_address}, #{Faker::Address.city}",
+    location: rehearsal_venue['formatted_address'],
     size_of_band: rand(1..7),
-    phone_number: "07#{rand(10**9)}"
+    phone_number: "07#{rand(10**9)}",
+    description: Faker::Hipster.sentences(number: 1)
   )
   venue.user = user
   venue.save!
 end
 
+# note: the api above also has google rating and opening hours, but i think we can leave these out for now.
+#in addition, the api has a geometry field which has a location field which has lat and lng fields. I think we can use this to plot the venues on a map.
+# docs https://developers.google.com/maps/documentation/places/web-service/search-text
+# it may also be able to return photos, but i think we can leave this out for now.
 puts "creating bookings"
 25.times do
   user = User.all.sample
@@ -58,7 +92,7 @@ puts "creating reviews"
 20.times do
   booking = Booking.all.sample
   review = Review.new(
-    comment: "This is a review",
+    comment: Faker::Hipster.paragraph,
     rating: rand(1..5)
   )
   review.booking = booking
@@ -129,3 +163,6 @@ end
 # end
 
 # puts "venue database seeded"
+
+# https://www.theparkstudios.com/?lightbox=dataItem-jxykp4lv
+# https://www.theparkstudios.com/live-rooms?pgid=kl6uvq44-e260e791-efe1-4831-b09b-b705eab6eff9

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -163,6 +163,3 @@ end
 # end
 
 # puts "venue database seeded"
-
-# https://www.theparkstudios.com/?lightbox=dataItem-jxykp4lv
-# https://www.theparkstudios.com/live-rooms?pgid=kl6uvq44-e260e791-efe1-4831-b09b-b705eab6eff9

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,17 +1,17 @@
 require 'date'
 
 #-----CLEANING DB-----
+puts "destroying review database"
+Review.destroy_all
+
+puts "destroying booking database"
+Booking.destroy_all
+
 puts "destroying venue database"
 Venue.destroy_all
 
 puts "destroying user database"
 User.destroy_all
-
-puts "destroying booking database"
-Booking.destroy_all
-
-puts "destroying review database"
-Review.destroy_all
 
 # -----------------
 


### PR DESCRIPTION
I have fixed the problem caused by destroying the database tables in the wrong order. This has been updated to reflect dependencies. Google places api has been implemented for the seeding of real venues and addresses. Note, this is limited to London at the moment, but this could be changed through multiple api calls if we wanted a variety. I think London is fine for demo purposes. We could also leverage this api later with user input in terms of location. The real addresses should make mapbox simpler to implement later on. I have left notes in the code about a few things. I realise i need to make small commits though!