### PR TITLE
update date in booking generation and fix venue description

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,7 +43,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_101405) do
   end
 
   create_table "bookings", force: :cascade do |t|
-    t.boolean "confirmed", default: false
+    t.boolean "confirmed"
     t.bigint "venue_id", null: false
     t.bigint "user_id", null: false
     t.date "start_date"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,7 +25,7 @@ puts "creating users"
   user = User.new(
     first_name: Faker::Name.first_name,
     last_name: Faker::Name.unique.last_name,
-    email: "#{Faker::Name.first_name}@gmail.com",
+    email: "#{Faker::Name.first_name}@#{Faker::Name.unique.last_name}.com",
     password: "banana"
   )
   user.save!
@@ -51,7 +51,7 @@ puts "creating bookings - 10 available"
 10.times do
   user = User.all.sample
   venue = Venue.all.sample
-  date = Date.today + rand(5..20)
+  date = Date.today + rand(5..25)
   booking = Booking.new(
     start_date: date,
     end_date: date + 1


### PR DESCRIPTION
I updated the booking generation so 5 venues will have the same date (and be unavailable to view when we filter) and 10 days with random dates for a 1 day hire. In addition, I moved the comments down and organised them so as to make the code easier to view, plus re-factored the JSON logic. Finally, I edited the venue description Faker gem as the current one yielded a sentence within [], \ and "" (screenshot attached).

<img width="960" alt="venue-description" src="https://user-images.githubusercontent.com/114738789/217586182-aed40704-7ac5-4838-b2cc-d065b12195a9.png">
