### PR TITLE
update booking model to change :confirmed default to false

### DIFF
--- a/db/migrate/20230209114953_add_default_to_bookings.rb
+++ b/db/migrate/20230209114953_add_default_to_bookings.rb
@@ -1,0 +1,5 @@
+class AddDefaultToBookings < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :bookings, :confirmed, from: nil, to: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_08_101405) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_09_114953) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,7 +43,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_101405) do
   end
 
   create_table "bookings", force: :cascade do |t|
-    t.boolean "confirmed"
+    t.boolean "confirmed", default: false
     t.bigint "venue_id", null: false
     t.bigint "user_id", null: false
     t.date "start_date"


### PR DESCRIPTION
The default for our `:confirmed` boolean was `nil` so this has been updated to default `false`