### PR TITLE
add date filter function to venues index

### DIFF
--- a/app/controllers/venues_controller.rb
+++ b/app/controllers/venues_controller.rb
@@ -1,7 +1,18 @@
 class VenuesController < ApplicationController
   before_action :set_venue, only: [:show]
   def index
-    @venues = Venue.all
+    if params[:start].present? || params[:end].present?
+      range = (params[:start].to_date..params[:end].to_date).to_a
+      @venues = []
+      Venue.all.each do |venue|
+        venue.bookings.each do |booking|
+          @venues << venue unless range.include?(booking.start_date || booking.end_date)
+        end
+      end
+      @venues
+    else
+      @venues = Venue.all
+    end
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_many :venues, dependent: :destroy
   has_many :bookings, dependent: :destroy
   has_many :reviews, through: :bookings
+  has_one_attached :photo
 
   validates :first_name, :last_name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   has_many :venues, dependent: :destroy
   has_many :bookings, dependent: :destroy
   has_many :reviews, through: :bookings
-  has_one_attached :photo
+  has_one_attached :avatar
 
   validates :first_name, :last_name, presence: true
 end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,8 +1,10 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
   <div class="container-fluid">
-    <%= link_to "#", class: "navbar-brand" do %>
-      <%= image_tag "https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/logo.png" %>
+    <%= link_to root_path, class: "navbar-brand" do %>
+      <%= image_tag "https://d1aeri3ty3izns.cloudfront.net/media/23/235459/1200/preview_4.jpg" %>
     <% end %>
+
+    <h2>Pay and Play</h2>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>

--- a/app/views/venues/index.html.erb
+++ b/app/views/venues/index.html.erb
@@ -1,4 +1,18 @@
 <div class="container">
+  <div class="row">
+    <form>
+      <label for="start" class="mt-2"><strong>Start date</strong></label>
+      <div class="col-2">
+        <input class="form-control my-2" id="start" name="start" type="date">
+      </div>
+      <label for="end"><strong>End date</strong></label>
+      <div class="col-2">
+        <input class="form-control my-2" id="end" name="end" type="date">
+      </div>
+      <button class="btn btn-success mt-2" type="submit">Search</button>
+    </form>
+  </div>
+
   <div class="row my-5 .d-flex justify-content-center">
     <% @venues.each do |venue| %>
       <div class="col-3 m-2">

--- a/app/views/venues/index.html.erb
+++ b/app/views/venues/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="row my-5">
+  <div class="row my-5 .d-flex justify-content-center">
     <% @venues.each do |venue| %>
       <div class="col-3 m-2">
         <div class="card h-100" style="width: 18rem;">

--- a/app/views/venues/index.html.erb
+++ b/app/views/venues/index.html.erb
@@ -1,13 +1,23 @@
-<div class="row my-5">
-  <% @venues.each do |venue| %>
-    <div class="col-2 m-2">
-      <div class="card h-100" style="width: 18rem;">
-        <img src="https://images.unsplash.com/photo-1534212758080-135b3affa932?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2071&q=80" class="card-img-top" alt="...">
-        <div class="card-body d-flex flex-column">
-          <h5 class="card-title"><%= link_to venue.name, venue_path(venue.id) %></h5>
-          <p class="card-text"><%= venue.description %></p>
+<div class="container">
+  <div class="row my-5">
+    <% @venues.each do |venue| %>
+      <div class="col-3 m-2">
+        <div class="card h-100" style="width: 18rem;">
+        <%= link_to venue_path(venue), target: :_blank do %>
+          <%= image_tag "https://images.unsplash.com/photo-1514320291840-2e0a9bf2a9ae?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=870&q=80", class: "card-img-top" %>
+        <% end %>
+          <div class="card-body d-flex flex-column">
+            <h5 class="card-title"><strong><%= link_to venue.name, venue_path(venue.id), class: "text-dark" %></strong></h5>
+            <p class="card-text"><%= venue.location %></p>
+            <p class="card-text mt-auto"><strong>£<%= venue.price_per_day %></strong> |
+            <% if venue.size_of_band == 1 %>
+              <%= venue.size_of_band %> person</p>
+            <% else %>
+              <%= venue.size_of_band %> people</p>
+            <% end %>
+          </div>
         </div>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,9 +2,9 @@ require 'date'
 require 'open-uri'
 require 'json'
 
-api_key = 'AIzaSyBhvbimgkK3MN2tHSRtpXDkLFYq91kmQHk'
-url = "https://maps.googleapis.com/maps/api/place/textsearch/json?query=music%20rehearsal%20venues%20in%20London&limit=15&key=#{api_key}"
-music_venues = JSON.parse(URI.open(url).read)['results']
+# api_key = 'AIzaSyBhvbimgkK3MN2tHSRtpXDkLFYq91kmQHk'
+# url = "https://maps.googleapis.com/maps/api/place/textsearch/json?query=music%20rehearsal%20venues%20in%20London&limit=15&key=#{api_key}"
+# music_venues = JSON.parse(URI.open(url).read)['results']
 
 #-----CLEANING DB-----
 puts "destroying review database"
@@ -34,11 +34,13 @@ end
 puts "creating venues"
 15.times do
   user = User.all.sample
-  rehearsal_venue = music_venues.sample
+  # rehearsal_venue = music_venues.sample
   venue = Venue.new(
-    name: rehearsal_venue['name'],
+    name: "This is a name",
+    # name: rehearsal_venue['name'],
     price_per_day: rand(50..100),
-    location: rehearsal_venue['formatted_address'],
+    # location: rehearsal_venue['formatted_address'],
+    location: "This is an address",
     size_of_band: rand(1..7),
     phone_number: "07#{rand(10**9)}",
     description: Faker::Hipster.paragraph


### PR DESCRIPTION
I added a function to search via date range for venues on the homepage. I am sure it needs some refactoring and it also doesn't work properly for overlapping dates (it should not show 3 venues with booking dates of 26-27, 26-27 and 25-26 if I enter 26-27, but the 25-26 venue still shows). It can work OK for demo#1 day and we can tweak it the week after.

Updated the view correspondingly.

Commented out parts of the seed as needed to re-seed and no need API key

Apologies - it looks like this PR also counts my previous PR's changes